### PR TITLE
[COOK-3528] Fix 'ufw::recipes' and 'ufw::databag' crash

### DIFF
--- a/recipes/databag.rb
+++ b/recipes/databag.rb
@@ -52,7 +52,7 @@ rlist.each do |entry|
     #add the list of firewall rules to the current list
     item = data_bag_item('firewall', entry)
     rules = item['rules']
-    node.override['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'] = node['firewall']['rules'].concat(rules) unless rules.nil?
   end
 end
 

--- a/recipes/databag.rb
+++ b/recipes/databag.rb
@@ -44,13 +44,15 @@ Chef::Log.debug "ufw::databag:rlist: #{rlist}"
 fw_db = data_bag('firewall')
 Chef::Log.debug "ufw::databag:firewall:#{fw_db}"
 
+node.override['firewall']['rules'] = [] unless node['firewall']['rules'].respond_to? :concat
+
 rlist.each do |entry|
   Chef::Log.debug "ufw::databag: \"#{entry}\""
   if fw_db.member?(entry)
     #add the list of firewall rules to the current list
     item = data_bag_item('firewall', entry)
     rules = item['rules']
-    node.set['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'].concat(rules) unless rules.nil?
   end
 end
 

--- a/recipes/recipes.rb
+++ b/recipes/recipes.rb
@@ -29,13 +29,13 @@ node.expand!.recipes.each do |recipe|
   if recipe != cookbook and node[cookbook] and node[cookbook]['firewall'] and node[cookbook]['firewall']['rules']
     rules = node[cookbook]['firewall']['rules']
     Chef::Log.debug "ufw::recipes:#{cookbook}:rules #{rules}"
-    node.override['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'] = node['firewall']['rules'].concat(rules) unless rules.nil?
   end
   #get the recipe attributes if there are any
   if node[recipe] and node[recipe]['firewall'] and node[recipe]['firewall']['rules']
     rules = node[recipe]['firewall']['rules']
     Chef::Log.debug "ufw::recipes:#{recipe}:rules #{rules}"
-    node.override['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'] = node['firewall']['rules'].concat(rules) unless rules.nil?
   end
 end
 

--- a/recipes/recipes.rb
+++ b/recipes/recipes.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+node.override['firewall']['rules'] = [] unless node['firewall']['rules'].respond_to? :concat
+
 # expand and parse the node's runlist for recipes and find attributes of the form node[<recipe>]['firewall']['rules']
 # append them to the node['firewall']['rules'] array attribute
 node.expand!.recipes.each do |recipe|
@@ -27,13 +29,13 @@ node.expand!.recipes.each do |recipe|
   if recipe != cookbook and node[cookbook] and node[cookbook]['firewall'] and node[cookbook]['firewall']['rules']
     rules = node[cookbook]['firewall']['rules']
     Chef::Log.debug "ufw::recipes:#{cookbook}:rules #{rules}"
-    node.set['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'].concat(rules) unless rules.nil?
   end
   #get the recipe attributes if there are any
   if node[recipe] and node[recipe]['firewall'] and node[recipe]['firewall']['rules']
     rules = node[recipe]['firewall']['rules']
     Chef::Log.debug "ufw::recipes:#{recipe}:rules #{rules}"
-    node.set['firewall']['rules'].concat(rules) unless rules.nil?
+    node.override['firewall']['rules'].concat(rules) unless rules.nil?
   end
 end
 


### PR DESCRIPTION
Fixes https://tickets.opscode.com/browse/COOK-3528

If a node had no firewall rules already it would crash when trying to do
the concat operation.

There was already a PR (https://github.com/opscode-cookbooks/ufw/pull/7/files) for the same bug but it wasn't merged and was using 'set' too much in my opinion.